### PR TITLE
Dom renders login form unless user is auth

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,3 +1,4 @@
 export const Nutshell = () => {
+    return console.log("test")
     // Render all your UI components here
 }

--- a/src/scripts/auth/RegisterForm.js
+++ b/src/scripts/auth/RegisterForm.js
@@ -40,6 +40,9 @@ eventHub.addEventListener("click", e => {
                 }
             })
         }
+        else {
+            window.alert("Username & email are required fields! 😠")
+        }
     }
 })
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,7 +1,21 @@
-import { LoginForm } from "./auth/LoginForm.js"
-import { RegisterForm } from "./auth/RegisterForm.js"
-import { Nutshell } from "./Nutshell.js"
+import { LoginForm } from "./auth/LoginForm.js";
+import { RegisterForm } from "./auth/RegisterForm.js";
+import { Nutshell } from "./Nutshell.js";
 
+const eventHub = document.querySelector(".container");
+
+// Render dashboard when user authenticates using the login form
+eventHub.addEventListener("userAuthenticated", (e) => {
+    Nutshell();
+});
+
+// If 
+if (sessionStorage.getItem("activeUser") === null) {
+    LoginForm();
+    RegisterForm();
+} else {
+    Nutshell();
+}
 
 /*
     1. Check if the user is authenticated by looking in session storage for `activeUser`


### PR DESCRIPTION
# Render login and register forms is user is authenticated
**Issue Ticket #13** 
Login and Register forms connect to database .json to create and use user data and then logs the user into the page. When logged in the user will see the nutshell UI instead of the login/registration form. If page is refreshed the Session Storage for the tab will remember the user that is logged in.

# Testing
1. create user in register form to add to database.json. 
2. When forms disappear look at the dev Tools to check if `console.log("test")` on nutshell.js is showing.
3. refresh the page and make sure the login/register forms do not show and console shows test. 
4. In dev tools look at Storage/Session Storage under the tab Application and the correct userId should be saved there.
5. close and reopen tab for the page and the login/registration forms should appear again since Session Storage will be cleared.